### PR TITLE
Add parametersToInclude and change eventsToInclude check

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -58,6 +58,12 @@
             "hint": "Comma separated list of events to include"
         },
         {
+            "key": "parametersToInclude",
+            "name": "Parameters to include",
+            "type": "string",
+            "hint": "Comma separated list of parameters to include"
+        },
+        {
             "key": "debugLogging",
             "name": "Enable debug logging",
             "type": "choice",

--- a/plugin.json
+++ b/plugin.json
@@ -55,13 +55,13 @@
             "key": "eventsToInclude",
             "name": "Events to include",
             "type": "string",
-            "hint": "Comma separated list of events to include"
+            "hint": "Comma separated list of events to include. If not set, all events will be sent."
         },
         {
             "key": "propertiesToInclude",
-            "name": "Parameters to include",
+            "name": "Properties to include",
             "type": "string",
-            "hint": "Comma separated list of parameters to include"
+            "hint": "Comma separated list of properties to include. If not set, all properties of the event will be sent."
         },
         {
             "key": "debugLogging",

--- a/plugin.json
+++ b/plugin.json
@@ -55,7 +55,7 @@
             "key": "eventsToInclude",
             "name": "Events to include",
             "type": "string",
-            "hint": "Comma separated list of events to include. If not set, all events will be sent."
+            "hint": "Comma separated list of events to include"
         },
         {
             "key": "propertiesToInclude",

--- a/plugin.json
+++ b/plugin.json
@@ -58,7 +58,7 @@
             "hint": "Comma separated list of events to include"
         },
         {
-            "key": "parametersToInclude",
+            "key": "propertiesToInclude",
             "name": "Parameters to include",
             "type": "string",
             "hint": "Comma separated list of parameters to include"

--- a/plugin.json
+++ b/plugin.json
@@ -55,13 +55,13 @@
             "key": "eventsToInclude",
             "name": "Events to include",
             "type": "string",
-            "hint": "Comma separated list of events to include"
+            "hint": "Comma separated list of events to include. If not set, no events will be sent"
         },
         {
             "key": "propertiesToInclude",
             "name": "Properties to include",
             "type": "string",
-            "hint": "Comma separated list of properties to include. If not set, all properties of the event will be sent."
+            "hint": "Comma separated list of properties to include. If not set, all properties of the event will be sent"
         },
         {
             "key": "debugLogging",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ interface SalesforcePluginMeta extends PluginMeta {
         consumerKey: string
         consumerSecret: string
         eventsToInclude: string
-        parametersToInclude: string
+        propertiesToInclude: string
         debugLogging: string
     }
     global: {
@@ -185,14 +185,19 @@ function getProperties(event: PluginEvent, { config }: SalesforcePluginMeta): Pr
     // reducer there's no way the properties will be undefined
     const { properties } = event
 
-    if (!properties) return {}
-    if (!config.parametersToInclude) return properties
+    if (!properties) {
+        return {}
+    }
 
-    const allParameters = config.parametersToInclude.split(',')
+    if (!config.propertiesToInclude?.trim()) {
+        return properties
+    }
+
+    const allParameters = config.propertiesToInclude.split(',')
     const propertyKeys = Object.keys(properties)
 
     const availableParameters = allParameters.reduce<Record<string, any>>((acc, currentValue) => {
-        if (propertyKeys.includes(currentValue)) {
+        if (propertyKeys.includes(currentValue.trim())) {
             acc[currentValue] = properties[currentValue]
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,12 +69,6 @@ async function sendEventToSalesforce(event: PluginEvent, meta: SalesforcePluginM
     try {
         const { config, global } = meta
 
-        const types = (config.eventsToInclude || '').split(',')
-
-        if (!types.includes(event.event) || !event.properties) {
-            return
-        }
-
         global.logger.debug('processing event: ', event?.event)
 
         const token = await getToken(meta)
@@ -162,10 +156,17 @@ export async function setupPlugin(meta: SalesforcePluginMeta) {
     })
 }
 
-export async function onEvent(event: PluginEvent, { global }: SalesforcePluginMeta) {
+export async function onEvent(event: PluginEvent, { global, config }: SalesforcePluginMeta) {
     if (!global.buffer) {
         throw new Error(`there is no buffer. setup must have failed, cannot process event: ${event.event}`)
     }
+
+    const types = (config.eventsToInclude || '').split(',')
+
+    if (!types.includes(event.event) || !event.properties) {
+        return
+    }
+
     const eventSize = JSON.stringify(event).length
     global.buffer.add(event, eventSize)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,8 +197,10 @@ function getProperties(event: PluginEvent, { config }: SalesforcePluginMeta): Pr
     const propertyKeys = Object.keys(properties)
 
     const availableParameters = allParameters.reduce<Record<string, any>>((acc, currentValue) => {
-        if (propertyKeys.includes(currentValue.trim())) {
-            acc[currentValue] = properties[currentValue]
+        const trimmedKey = currentValue.trim()
+
+        if (propertyKeys.includes(trimmedKey)) {
+            acc[trimmedKey] = properties[trimmedKey]
         }
 
         return acc


### PR DESCRIPTION
## Changes

- Now checking if the event is in the `eventsToInclude` list before adding it to the buffer.
- A new property `parametersToInclude`. 

## Explanation

### Events to include

We have a high volume of events, and the ones we want to send to Salesforce are not that common. If we were to check if the events are in the `eventsToInclude` list only in the `sendEventToSalesforce`, most of the buffer would go to waste. 

This isn't broken now, but I assume it'll be easier to debug if the plug-in breaks.

### Parameters to include

Salesforce is strict with the parameters we send in the `/services/data/v55.0/sobjects/Lead` endpoint -- only accepting those that match existing columns in the Lead object (same for any sort of object).

We have a few parameters in our events (`$ip`, `distinct_id` etc) that would break the integration, hence the `parametersToInclude` config – only sending the parameters we want.

## Final notes

I haven't tested these changes as there's no way to run custom plugins in PostHog Cloud.
