### PR TITLE
feat: v2 for multi endpoint mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ For example:
 ```
 eventEndpointMapping: {
     "user signed up": {
-        salesforcePath: "Lead",
-        propertiesToInclude: "name,email,company"
-        method: "POST"
+        "salesforcePath": "Lead",
+        "propertiesToInclude": "name,email,company",
+        "method": "POST"
     }
     "insight analyzed": {
-        salesforcePath: "Engagement",
-        propertiesToInclude: "insight,user,duration"
-        method: "POST"
+        "salesforcePath": "Engagement",
+        "propertiesToInclude": "insight,user,duration",
+        "method": "POST"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,76 @@
 
 Relay PostHog events to Salesforce
 
+## Config
+
+### V1 config
+
+```
+{
+            "key": "eventsToInclude",
+            "name": "Events to include",
+            "type": "string",
+            "hint": "Comma separated list of events to include. If not set, no events will be sent"
+        },
+        {
+            "key": "eventPath",
+            "name": "Path of the url where events will go to. No leading forward slash",
+            "type": "string",
+            "required": true
+        },
+        {
+            "key": "eventMethodType",
+            "name": "The type of method for the event url",
+            "default": "POST",
+            "type": "string"
+        },
+        {
+            "key": "propertiesToInclude",
+            "name": "Properties to include",
+            "type": "string",
+            "hint": "Comma separated list of properties to include. If not set, all properties of the event will be sent"
+        },
+```
+
+Given a list of `eventsToInclude` and `propertiesToInclude`, the plugin will send a request to the `eventPath` using the `eventMethodType` method type.
+
+Only properties on the event that are in the `propertiesToInclude` list will be sent.
+
+### V2 config
+
+```
+        {
+            "key": "eventEndpointMapping",
+            "name": "Event endpoint mapping",
+            "type": "json",
+            "hint": "⚠️ For advanced uses only ⚠️ Allows you to map events to different SalesForce endpoints. See https://github.com/Vinovest/posthog-salesforce/blob/main/README.md for an example.",
+            "default": ""
+        },
+```
+
+In order to support sending events to different endpoints, you can use the `eventEndpointMapping` config. This config is a JSON object where the keys are the event names and the values are the endpoint paths, method type and properties to include.
+
+For example:
+
+```
+eventEndpointMapping: {
+    "user signed up": {
+        salesforcePath: "Lead",
+        propertiesToInclude: "name,email,company"
+        method: "POST"
+    }
+    "insight analyzed": {
+        salesforcePath: "Engagement",
+        propertiesToInclude: "insight,user,duration"
+        method: "POST"
+    }
+}
+```
+
+### Setting config
+
+V1 and V2 config cannot be set at the same time.
+
 ## Questions?
 
 ### [Join the PostHog Users Slack community.](https://posthog.com/slack)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@vinovest/posthog-salesforce",
     "displayName": "Posthog Salesforce Plugin",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "keywords": [
         "posthog",
         "plugin"

--- a/plugin.json
+++ b/plugin.json
@@ -67,7 +67,7 @@
             "key": "eventEndpointMapping",
             "name": "Event endpoint mapping",
             "type": "json",
-            "hint": "⚠️ For advanced uses only ⚠️ Allows you to map events to different SalesForce endpoints. See https://github.com/Vinovest/posthog-salesforce/blob/main/README.md for an example.",
+            "hint": "⚠️ For advanced uses only ⚠️ Allows you to map events to different SalesForce endpoints. See https://github.com/PostHog/salesforce-plugin/blob/main/README.md for an example.",
             "default": ""
         },
         {

--- a/plugin.json
+++ b/plugin.json
@@ -13,18 +13,6 @@
             "required": true
         },
         {
-            "key": "eventPath",
-            "name": "Path of the url where events will go to. No leading forward slash",
-            "type": "string",
-            "required": true
-        },
-        {
-            "key": "eventMethodType",
-            "name": "The type of method for the event url",
-            "default": "POST",
-            "type": "string"
-        },
-        {
             "key": "username",
             "name": "Username",
             "type": "string",
@@ -58,10 +46,29 @@
             "hint": "Comma separated list of events to include. If not set, no events will be sent"
         },
         {
+            "key": "eventPath",
+            "name": "Path of the url where events will go to. No leading forward slash",
+            "type": "string",
+            "required": true
+        },
+        {
+            "key": "eventMethodType",
+            "name": "The type of method for the event url",
+            "default": "POST",
+            "type": "string"
+        },
+        {
             "key": "propertiesToInclude",
             "name": "Properties to include",
             "type": "string",
             "hint": "Comma separated list of properties to include. If not set, all properties of the event will be sent"
+        },
+        {
+            "key": "eventEndpointMapping",
+            "name": "Event endpoint mapping",
+            "type": "json",
+            "hint": "⚠️ For advanced uses only ⚠️ Allows you to map events to different SalesForce endpoints. See https://github.com/Vinovest/posthog-salesforce/blob/main/README.md for an example.",
+            "default": ""
         },
         {
             "key": "debugLogging",

--- a/plugin.json
+++ b/plugin.json
@@ -48,8 +48,7 @@
         {
             "key": "eventPath",
             "name": "Path of the url where events will go to. No leading forward slash",
-            "type": "string",
-            "required": true
+            "type": "string"
         },
         {
             "key": "eventMethodType",

--- a/src/configValidation.test.ts
+++ b/src/configValidation.test.ts
@@ -12,8 +12,9 @@ describe('config validation', () => {
             password: '',
             consumerKey: '',
             consumerSecret: '',
-            eventsToInclude: '',
+            eventsToInclude: '$pageview',
             propertiesToInclude: '',
+            eventEndpointMapping: '',
             debugLogging: '',
         }
     })

--- a/src/configValidation.test.ts
+++ b/src/configValidation.test.ts
@@ -5,13 +5,13 @@ describe('config validation', () => {
 
     beforeEach(() => {
         config = {
-            salesforceHost: '',
-            eventPath: '',
-            eventMethodType: '',
-            username: '',
-            password: '',
-            consumerKey: '',
-            consumerSecret: '',
+            salesforceHost: 'https://example.io',
+            eventPath: 'test',
+            eventMethodType: 'test',
+            username: 'test',
+            password: 'test',
+            consumerKey: 'test',
+            consumerSecret: 'test',
             eventsToInclude: '$pageview',
             propertiesToInclude: '',
             eventEndpointMapping: '',
@@ -32,5 +32,20 @@ describe('config validation', () => {
     it('rejects an FTP URL', () => {
         config.salesforceHost = 'ftp://bbc.co.uk'
         expect(() => verifyConfig({ config } as SalesforcePluginMeta)).toThrowError('host not a valid URL!')
+    })
+
+    it('allows empty eventPath when v2 mapping is present', () => {
+        config.eventsToInclude = ''
+        config.eventEndpointMapping = JSON.stringify({ pageview: { salesforcePath: '/test', method: 'POST' } })
+        expect(() => verifyConfig({ config } as SalesforcePluginMeta)).not.toThrowError()
+    })
+
+    it('requires eventPath when v2 mapping is not present', () => {
+        config.eventsToInclude = '$pageview'
+        config.eventPath = ''
+        config.eventEndpointMapping = ''
+        expect(() => verifyConfig({ config } as SalesforcePluginMeta)).toThrowError(
+            'If you are not providing an eventEndpointMapping then you must provide the salesforce path.'
+        )
     })
 })

--- a/src/eventSinkMapping.test.ts
+++ b/src/eventSinkMapping.test.ts
@@ -1,0 +1,177 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+import {
+    EventSink,
+    EventToSinkMapping,
+    parseEventSinkConfig,
+    SalesforcePluginConfig,
+    SalesforcePluginMeta,
+    sendEventToSalesforce,
+    verifyConfig,
+} from '.'
+
+const mockFetch = jest.fn()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(global as any).fetch = mockFetch
+
+describe('event sink mapping', () => {
+    const invalidMapping: EventToSinkMapping = {
+        a: {
+            salesforcePath: 'something',
+            propertiesToInclude: '',
+            method: 'POST',
+        },
+        b: {
+            salesforcePath: '', // invalid because it does not have a salesforce path
+            propertiesToInclude: '',
+            method: 'POST',
+        },
+    }
+
+    const missingMethodInvalidMapping: EventToSinkMapping = {
+        a: {
+            salesforcePath: 'something',
+            propertiesToInclude: '',
+        } as EventSink,
+    }
+
+    const validMapping: EventToSinkMapping = {
+        $pageview: {
+            salesforcePath: 'something',
+            propertiesToInclude: 'one,two,three',
+            method: 'POST',
+        },
+    }
+
+    describe('parsing', () => {
+        it('can parse a valid event sink mapping', () => {
+            const config = ({ eventEndpointMapping: JSON.stringify(validMapping) } as unknown) as SalesforcePluginConfig
+            const mapping = parseEventSinkConfig(config)
+            expect(mapping).toEqual(validMapping)
+        })
+
+        it('can parse an empty event sink mapping', () => {
+            const config = ({ eventEndpointMapping: '' } as unknown) as SalesforcePluginConfig
+            const mapping = parseEventSinkConfig(config)
+            expect(mapping).toEqual(null)
+        })
+
+        it('can parse nonsense as an empty event sink mapping', () => {
+            const config = ({ eventEndpointMapping: '🤘' } as unknown) as SalesforcePluginConfig
+            const mapping = parseEventSinkConfig(config)
+            expect(mapping).toEqual(null)
+        })
+    })
+
+    describe('validation', () => {
+        it('can validate an event sink mapping with missing salesforcePath', () => {
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: JSON.stringify(invalidMapping),
+                    },
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
+        })
+
+        it('can validate an event sink mapping with missing method', () => {
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: JSON.stringify(missingMethodInvalidMapping),
+                    },
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('You must provide a method for each mapping in config.eventEndpointMapping.')
+        })
+
+        it('can validate invalid JSON in EventToSinkMapping', () => {
+            const mapping = ({
+                really: 'not an event to sink mapping',
+            } as unknown) as EventToSinkMapping
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: JSON.stringify(mapping),
+                    },
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
+        })
+
+        it('can validate eventsToInclude must be present if an event sink mapping is not', () => {
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: '',
+                    },
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('If you are not providing an eventEndpointMapping then you must provide events to include.')
+        })
+
+        it('can validate that you should not send v1 and v2 config', () => {
+            const mapping: EventToSinkMapping = {
+                $pageView: {
+                    salesforcePath: 'something',
+                    propertiesToInclude: '',
+                    method: 'POST',
+                },
+            }
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: JSON.stringify(mapping),
+                        eventsToInclude: '$pageView',
+                    },
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('You should not provide both eventsToInclude and eventMapping.')
+        })
+    })
+
+    describe('sending to sink', () => {
+        const global = ({ logger: { debug: jest.fn(), error: jest.fn() } } as unknown) as SalesforcePluginMeta['global']
+        const config = {
+            salesforceHost: 'https://example.io',
+            eventMethodType: 'POST',
+            eventPath: '',
+            username: '',
+            password: '',
+            consumerKey: '',
+            consumerSecret: '',
+            eventsToInclude: '',
+            debugLogging: 'false',
+            eventEndpointMapping: JSON.stringify(validMapping),
+        }
+
+        beforeEach(() => {
+            mockFetch.mockClear()
+            mockFetch.mockReturnValue(Promise.resolve({ status: 200 }))
+        })
+
+        it('does not send to a sink if there is no mapping for the event', async () => {
+            await sendEventToSalesforce(
+                { event: 'uninteresting' } as PluginEvent,
+                ({ config, global } as unknown) as SalesforcePluginMeta,
+                'token'
+            )
+            expect(mockFetch).not.toHaveBeenCalled()
+        })
+
+        it('does send to a sink if there is a mapping for the event', async () => {
+            await sendEventToSalesforce(
+                ({
+                    event: '$pageview',
+                    properties: { unwanted: 'excluded', two: 'includes' },
+                } as unknown) as PluginEvent,
+                ({
+                    global: global,
+                    config: config,
+                    cache: undefined,
+                } as unknown) as SalesforcePluginMeta,
+                'the bearer token'
+            )
+            expect(mockFetch).toHaveBeenCalledWith('https://example.io/something', {
+                body: '{"two":"includes"}',
+                headers: { Authorization: 'Bearer the bearer token', 'Content-Type': 'application/json' },
+                method: 'POST',
+            })
+        })
+    })
+})

--- a/src/eventSinkMapping.test.ts
+++ b/src/eventSinkMapping.test.ts
@@ -57,8 +57,9 @@ describe('event sink mapping', () => {
 
         it('can parse nonsense as an empty event sink mapping', () => {
             const config = ({ eventEndpointMapping: '🤘' } as unknown) as SalesforcePluginConfig
-            const mapping = parseEventSinkConfig(config)
-            expect(mapping).toEqual(null)
+            expect(() => parseEventSinkConfig(config)).toThrowError(
+                'eventEndpointMapping must be an empty string or contain valid JSON!'
+            )
         })
     })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,7 @@ export const parseEventSinkConfig = (config: SalesforcePluginConfig): EventToSin
         try {
             eventMapping = JSON.parse(config.eventEndpointMapping) as EventToSinkMapping
         } catch (e) {
-            // TODO this should go into logs
-            // swallow exceptions parsing the event mapping
+            throw new Error('eventEndpointMapping must be an empty string or contain valid JSON!')
         }
     }
     return eventMapping

--- a/src/onEvent.test.ts
+++ b/src/onEvent.test.ts
@@ -1,0 +1,74 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+import { onEvent, SalesforcePluginConfig, SalesforcePluginGlobal, SalesforcePluginMeta } from '.'
+
+const mockBuffer = { add: jest.fn() }
+
+describe('onEvent', () => {
+    let config: SalesforcePluginConfig
+
+    beforeEach(() => {
+        mockBuffer.add.mockClear()
+
+        config = {
+            salesforceHost: 'https://example.io',
+            eventPath: 'test',
+            eventMethodType: 'test',
+            username: 'test',
+            password: 'test',
+            consumerKey: 'test',
+            consumerSecret: 'test',
+            eventsToInclude: '$pageview',
+            propertiesToInclude: '',
+            eventEndpointMapping: '',
+            debugLogging: '',
+        }
+    })
+
+    it('throws an error if there is no buffer', async () => {
+        const global = ({ buffer: undefined } as unknown) as SalesforcePluginGlobal
+
+        expect(() =>
+            onEvent({ event: 'test' } as PluginEvent, { global, config } as SalesforcePluginMeta)
+        ).rejects.toThrowError('There is no buffer. Setup must have failed, cannot process event: test')
+    })
+
+    it('adds the event to the buffer with v1 mapping that matches', async () => {
+        const global = ({ buffer: mockBuffer } as unknown) as SalesforcePluginGlobal
+        config.eventsToInclude = 'test'
+
+        await onEvent({ event: 'test' } as PluginEvent, { global, config } as SalesforcePluginMeta)
+
+        expect(mockBuffer.add).toHaveBeenCalledWith({ event: 'test' }, 16)
+    })
+
+    it('skips the event with v1 mapping that does not match', async () => {
+        const global = ({ buffer: mockBuffer } as unknown) as SalesforcePluginGlobal
+        config.eventsToInclude = 'to match'
+
+        await onEvent({ event: 'not to match' } as PluginEvent, { global, config } as SalesforcePluginMeta)
+
+        expect(mockBuffer.add).not.toHaveBeenCalled()
+    })
+
+    it('adds the event to the buffer with v2 mapping that matches', async () => {
+        const global = ({ buffer: mockBuffer } as unknown) as SalesforcePluginGlobal
+        config.eventsToInclude = ''
+        config.eventPath = ''
+        config.eventEndpointMapping = JSON.stringify({ test: { salesforcePath: '/test', method: 'POST' } })
+
+        await onEvent({ event: 'test' } as PluginEvent, { global, config } as SalesforcePluginMeta)
+
+        expect(mockBuffer.add).toHaveBeenCalledWith({ event: 'test' }, 16)
+    })
+
+    it('skips the event with v2 mapping that does not match', async () => {
+        const global = ({ buffer: mockBuffer } as unknown) as SalesforcePluginGlobal
+        config.eventsToInclude = ''
+        config.eventPath = ''
+        config.eventEndpointMapping = JSON.stringify({ 'to match': { salesforcePath: '/test', method: 'POST' } })
+
+        await onEvent({ event: 'not to match' } as PluginEvent, { global, config } as SalesforcePluginMeta)
+
+        expect(mockBuffer.add).not.toHaveBeenCalled()
+    })
+})

--- a/src/sendEventToSalesforce.test.ts
+++ b/src/sendEventToSalesforce.test.ts
@@ -38,4 +38,20 @@ describe('sendEventsToSalesforce', () => {
             method: 'POST',
         })
     })
+
+    it('can send an event to salesforce', async () => {
+        config = {
+            ...config,
+            eventsToInclude: '$pageview,checkout',
+            eventPath: 'test',
+        } as SalesforcePluginConfig
+
+        await sendEventToSalesforce(
+            ({ event: 'should not send', properties: { $current_url: 'https://home/io' } } as unknown) as PluginEvent,
+            ({ config, global } as unknown) as SalesforcePluginMeta,
+            'token'
+        )
+
+        expect(mockFetch).not.toHaveBeenCalled()
+    })
 })


### PR DESCRIPTION
## Changes

see https://github.com/PostHog/apps/issues/11

* adds a new method for sending events to the salesforce sink that uses a JSON mapping to allow multiple endpoints

Testing locally with v2 config set as:

```
{
    "$pageview": {
        "salesforcePath": "Lead",
        "propertiesToInclude": "$current_url",
        "method": "POST"
    },
    "$autocapture": {
        "salesforcePath": "Event",
        "propertiesToInclude": "$current_url",
        "method": "POST"
    }
}
```

I see:

<img width="841" alt="Screenshot 2023-02-03 at 09 00 23" src="https://user-images.githubusercontent.com/984817/216557072-c6ea6936-b095-459d-af1c-ea0d82e00f43.png">

These show 404 as results because I don't know what salesforcePaths are valid but shows we can process and act on v1 and v2 config

## Checklist

-   [x] Tests for new code
