### PR TITLE
Remove deprecated buffer usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@vinovest/posthog-salesforce",
-    "version": "1.1.0",
+    "version": "2.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@vinovest/posthog-salesforce",
-            "version": "1.1.0",
+            "version": "2.0.1",
             "license": "MIT",
             "dependencies": {
                 "@posthog/plugin-contrib": "^0.0.5"

--- a/src/onEvent.test.ts
+++ b/src/onEvent.test.ts
@@ -1,13 +1,10 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { onEvent, SalesforcePluginConfig, SalesforcePluginGlobal, SalesforcePluginMeta } from '.'
-
-const mockBuffer = { add: jest.fn() }
+import { shouldSendEvent, SalesforcePluginConfig, SalesforcePluginGlobal, SalesforcePluginMeta } from '.'
 
 describe('onEvent', () => {
     let config: SalesforcePluginConfig
 
     beforeEach(() => {
-        mockBuffer.add.mockClear()
 
         config = {
             salesforceHost: 'https://example.io',
@@ -24,51 +21,35 @@ describe('onEvent', () => {
         }
     })
 
-    it('throws an error if there is no buffer', async () => {
-        const global = ({ buffer: undefined } as unknown) as SalesforcePluginGlobal
-
-        expect(() =>
-            onEvent({ event: 'test' } as PluginEvent, { global, config } as SalesforcePluginMeta)
-        ).rejects.toThrowError('There is no buffer. Setup must have failed, cannot process event: test')
-    })
-
-    it('adds the event to the buffer with v1 mapping that matches', async () => {
-        const global = ({ buffer: mockBuffer } as unknown) as SalesforcePluginGlobal
+    it('adds the event with v1 mapping that matches', async () => {
         config.eventsToInclude = 'test'
 
-        await onEvent({ event: 'test' } as PluginEvent, { global, config } as SalesforcePluginMeta)
-
-        expect(mockBuffer.add).toHaveBeenCalledWith({ event: 'test' }, 16)
+        const res = await shouldSendEvent({ event: 'test' } as PluginEvent, { config } as SalesforcePluginMeta)
+        expect(res).toBeTruthy()
     })
 
     it('skips the event with v1 mapping that does not match', async () => {
-        const global = ({ buffer: mockBuffer } as unknown) as SalesforcePluginGlobal
         config.eventsToInclude = 'to match'
 
-        await onEvent({ event: 'not to match' } as PluginEvent, { global, config } as SalesforcePluginMeta)
-
-        expect(mockBuffer.add).not.toHaveBeenCalled()
+        const res = await shouldSendEvent({ event: 'not to match' } as PluginEvent, { config } as SalesforcePluginMeta)
+        expect(res).toBeFalsy()
     })
 
-    it('adds the event to the buffer with v2 mapping that matches', async () => {
-        const global = ({ buffer: mockBuffer } as unknown) as SalesforcePluginGlobal
+    it('adds the event with v2 mapping that matches', async () => {
         config.eventsToInclude = ''
         config.eventPath = ''
         config.eventEndpointMapping = JSON.stringify({ test: { salesforcePath: '/test', method: 'POST' } })
 
-        await onEvent({ event: 'test' } as PluginEvent, { global, config } as SalesforcePluginMeta)
-
-        expect(mockBuffer.add).toHaveBeenCalledWith({ event: 'test' }, 16)
+        const res = await shouldSendEvent({ event: 'test' } as PluginEvent, { config } as SalesforcePluginMeta)
+        expect(res).toBeTruthy()
     })
 
     it('skips the event with v2 mapping that does not match', async () => {
-        const global = ({ buffer: mockBuffer } as unknown) as SalesforcePluginGlobal
         config.eventsToInclude = ''
         config.eventPath = ''
         config.eventEndpointMapping = JSON.stringify({ 'to match': { salesforcePath: '/test', method: 'POST' } })
 
-        await onEvent({ event: 'not to match' } as PluginEvent, { global, config } as SalesforcePluginMeta)
-
-        expect(mockBuffer.add).not.toHaveBeenCalled()
+        const res = await shouldSendEvent({ event: 'not to match' } as PluginEvent, { config } as SalesforcePluginMeta)
+        expect(res).toBeFalsy()
     })
 })


### PR DESCRIPTION
## Changes

Buffer has been deprecated for a while, we're removing the code to support it. The app will now just send each event directly.

...

## Checklist

-   [ ] Tests for new code
