### PR TITLE
Add salesforce plugin field mapping index.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ eventEndpointMapping: {
         "propertiesToInclude": "insight,user,duration",
         "method": "POST"
         // No fieldMappings, so the property names will be used as the field names
-        // when fieldMappings are not provided the property names in PostHog will be useed
+        // when fieldMappings are not provided the property names in PostHog will be used
         // these must exactly match the fields expected by SalesForce
     }
 }

--- a/README.md
+++ b/README.md
@@ -59,11 +59,20 @@ eventEndpointMapping: {
         "salesforcePath": "Lead",
         "propertiesToInclude": "name,email,company",
         "method": "POST"
+        // SalesForce can be very strict about what fields it accepts
+        // you can provide a mapping of PostHog properties to SalesForce fields
+        "fieldMappings": {
+            email: "Email",
+            name: "FullName", 
+        }
     }
     "insight analyzed": {
         "salesforcePath": "Engagement",
         "propertiesToInclude": "insight,user,duration",
         "method": "POST"
+        // No fieldMappings, so the property names will be used as the field names
+        // when fieldMappings are not provided the property names in PostHog will be useed
+        // these must exactly match the fields expected by SalesForce
     }
 }
 ```

--- a/plugin.json
+++ b/plugin.json
@@ -70,6 +70,13 @@
             "default": ""
         },
         {
+            "key": "fieldMappings",
+            "name": "Event to salesforce field mapping",
+            "type": "json",
+            "hint": "SalesForce can be strict about field names, if your posthog event property names don't match then you can map them using this. See https://github.com/PostHog/salesforce-plugin/blob/main/README.md for an example.",
+            "default": ""
+        },
+        {
             "key": "debugLogging",
             "name": "Enable debug logging",
             "type": "choice",

--- a/src/eventSinkMapping.test.ts
+++ b/src/eventSinkMapping.test.ts
@@ -14,171 +14,169 @@ const mockFetch = jest.fn()
 ;(global as any).fetch = mockFetch
 
 describe('event sink mapping', () => {
-    describe('without field mappings', () => {
-        const invalidMapping: EventToSinkMapping = {
-            a: {
-                salesforcePath: 'something',
-                propertiesToInclude: '',
-                method: 'POST',
-            },
-            b: {
-                salesforcePath: '', // invalid because it does not have a salesforce path
-                propertiesToInclude: '',
-                method: 'POST',
-            },
-        }
+    const invalidMapping: EventToSinkMapping = {
+        a: {
+            salesforcePath: 'something',
+            propertiesToInclude: '',
+            method: 'POST',
+        },
+        b: {
+            salesforcePath: '', // invalid because it does not have a salesforce path
+            propertiesToInclude: '',
+            method: 'POST',
+        },
+    }
 
-        const missingMethodInvalidMapping: EventToSinkMapping = {
-            a: {
-                salesforcePath: 'something',
-                propertiesToInclude: '',
-            } as EventSink,
-        }
+    const missingMethodInvalidMapping: EventToSinkMapping = {
+        a: {
+            salesforcePath: 'something',
+            propertiesToInclude: '',
+        } as EventSink,
+    }
 
-        const validMapping: EventToSinkMapping = {
-            $pageview: {
-                salesforcePath: 'something',
-                propertiesToInclude: 'one,two,three',
-                method: 'POST',
-            },
-        }
+    const validMapping: EventToSinkMapping = {
+        $pageview: {
+            salesforcePath: 'something',
+            propertiesToInclude: 'one,two,three',
+            method: 'POST',
+        },
+    }
 
-        describe('parsing', () => {
-            it('can parse a valid event sink mapping', () => {
-                const config = ({ eventEndpointMapping: JSON.stringify(validMapping) } as unknown) as SalesforcePluginConfig
-                const mapping = parseEventSinkConfig(config)
-                expect(mapping).toEqual(validMapping)
-            })
-
-            it('can parse an empty event sink mapping', () => {
-                const config = ({ eventEndpointMapping: '' } as unknown) as SalesforcePluginConfig
-                const mapping = parseEventSinkConfig(config)
-                expect(mapping).toEqual(null)
-            })
-
-            it('can parse nonsense as an empty event sink mapping', () => {
-                const config = ({ eventEndpointMapping: '🤘' } as unknown) as SalesforcePluginConfig
-                expect(() => parseEventSinkConfig(config)).toThrowError(
-                    'eventEndpointMapping must be an empty string or contain valid JSON!',
-                )
-            })
+    describe('parsing', () => {
+        it('can parse a valid event sink mapping', () => {
+            const config = ({ eventEndpointMapping: JSON.stringify(validMapping) } as unknown) as SalesforcePluginConfig
+            const mapping = parseEventSinkConfig(config)
+            expect(mapping).toEqual(validMapping)
         })
 
-        describe('validation', () => {
-            it('can validate an event sink mapping with missing salesforcePath', () => {
-                expect(() => {
-                    verifyConfig(({
-                        config: {
-                            eventEndpointMapping: JSON.stringify(invalidMapping),
-                        },
-                    } as unknown) as SalesforcePluginMeta)
-                }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
-            })
+        it('can parse an empty event sink mapping', () => {
+            const config = ({ eventEndpointMapping: '' } as unknown) as SalesforcePluginConfig
+            const mapping = parseEventSinkConfig(config)
+            expect(mapping).toEqual(null)
+        })
 
-            it('can validate an event sink mapping with missing method', () => {
-                expect(() => {
-                    verifyConfig(({
-                        config: {
-                            eventEndpointMapping: JSON.stringify(missingMethodInvalidMapping),
-                        },
-                    } as unknown) as SalesforcePluginMeta)
-                }).toThrowError('You must provide a method for each mapping in config.eventEndpointMapping.')
-            })
+        it('can parse nonsense as an empty event sink mapping', () => {
+            const config = ({ eventEndpointMapping: '🤘' } as unknown) as SalesforcePluginConfig
+            expect(() => parseEventSinkConfig(config)).toThrowError(
+                'eventEndpointMapping must be an empty string or contain valid JSON!',
+            )
+        })
+    })
 
-            it('can validate invalid JSON in EventToSinkMapping', () => {
-                const mapping = ({
-                    really: 'not an event to sink mapping',
-                } as unknown) as EventToSinkMapping
-                expect(() => {
-                    verifyConfig(({
-                        config: {
-                            eventEndpointMapping: JSON.stringify(mapping),
-                        },
-                    } as unknown) as SalesforcePluginMeta)
-                }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
-            })
-
-            it('can validate eventsToInclude must be present if an event sink mapping is not', () => {
-                expect(() => {
-                    verifyConfig(({
-                        config: {
-                            eventEndpointMapping: '',
-                        },
-                    } as unknown) as SalesforcePluginMeta)
-                }).toThrowError('If you are not providing an eventEndpointMapping then you must provide events to include.')
-            })
-
-            it('can validate that you should not send v1 and v2 config', () => {
-                const mapping: EventToSinkMapping = {
-                    $pageView: {
-                        salesforcePath: 'something',
-                        propertiesToInclude: '',
-                        method: 'POST',
+    describe('validation', () => {
+        it('can validate an event sink mapping with missing salesforcePath', () => {
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: JSON.stringify(invalidMapping),
                     },
-                }
-                expect(() => {
-                    verifyConfig(({
-                        config: {
-                            eventEndpointMapping: JSON.stringify(mapping),
-                            eventsToInclude: '$pageView',
-                        },
-                    } as unknown) as SalesforcePluginMeta)
-                }).toThrowError('You should not provide both eventsToInclude and eventMapping.')
-            })
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
         })
 
-        describe('sending to sink', () => {
-            const global = ({
-                logger: {
-                    debug: jest.fn(),
-                    error: jest.fn(),
-                },
-            } as unknown) as SalesforcePluginMeta['global']
-            const config = {
-                salesforceHost: 'https://example.io',
-                eventMethodType: 'POST',
-                eventPath: '',
-                username: '',
-                password: '',
-                consumerKey: '',
-                consumerSecret: '',
-                eventsToInclude: '',
-                debugLogging: 'false',
-                eventEndpointMapping: JSON.stringify(validMapping),
-            }
+        it('can validate an event sink mapping with missing method', () => {
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: JSON.stringify(missingMethodInvalidMapping),
+                    },
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('You must provide a method for each mapping in config.eventEndpointMapping.')
+        })
 
-            beforeEach(() => {
-                mockFetch.mockClear()
-                mockFetch.mockReturnValue(Promise.resolve({ status: 200 }))
-            })
+        it('can validate invalid JSON in EventToSinkMapping', () => {
+            const mapping = ({
+                really: 'not an event to sink mapping',
+            } as unknown) as EventToSinkMapping
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: JSON.stringify(mapping),
+                    },
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
+        })
 
-            it('does not send to a sink if there is no mapping for the event', async () => {
-                await sendEventToSalesforce(
-                    { event: 'uninteresting' } as PluginEvent,
-                    ({ config, global } as unknown) as SalesforcePluginMeta,
-                    'token',
-                )
-                expect(mockFetch).not.toHaveBeenCalled()
-            })
+        it('can validate eventsToInclude must be present if an event sink mapping is not', () => {
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: '',
+                    },
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('If you are not providing an eventEndpointMapping then you must provide events to include.')
+        })
 
-            it('does send to a sink if there is a mapping for the event', async () => {
-                await sendEventToSalesforce(
-                    ({
-                        event: '$pageview',
-                        properties: { unwanted: 'excluded', two: 'includes' },
-                    } as unknown) as PluginEvent,
-                    ({
-                        global: global,
-                        config: config,
-                        cache: undefined,
-                    } as unknown) as SalesforcePluginMeta,
-                    'the bearer token',
-                )
-                expect(mockFetch).toHaveBeenCalledWith('https://example.io/something', {
-                    body: '{"two":"includes"}',
-                    headers: { Authorization: 'Bearer the bearer token', 'Content-Type': 'application/json' },
+        it('can validate that you should not send v1 and v2 config', () => {
+            const mapping: EventToSinkMapping = {
+                $pageView: {
+                    salesforcePath: 'something',
+                    propertiesToInclude: '',
                     method: 'POST',
-                })
+                },
+            }
+            expect(() => {
+                verifyConfig(({
+                    config: {
+                        eventEndpointMapping: JSON.stringify(mapping),
+                        eventsToInclude: '$pageView',
+                    },
+                } as unknown) as SalesforcePluginMeta)
+            }).toThrowError('You should not provide both eventsToInclude and eventMapping.')
+        })
+    })
+
+    describe('sending to sink', () => {
+        const global = ({
+            logger: {
+                debug: jest.fn(),
+                error: jest.fn(),
+            },
+        } as unknown) as SalesforcePluginMeta['global']
+        const config = {
+            salesforceHost: 'https://example.io',
+            eventMethodType: 'POST',
+            eventPath: '',
+            username: '',
+            password: '',
+            consumerKey: '',
+            consumerSecret: '',
+            eventsToInclude: '',
+            debugLogging: 'false',
+            eventEndpointMapping: JSON.stringify(validMapping),
+        }
+
+        beforeEach(() => {
+            mockFetch.mockClear()
+            mockFetch.mockReturnValue(Promise.resolve({ status: 200 }))
+        })
+
+        it('does not send to a sink if there is no mapping for the event', async () => {
+            await sendEventToSalesforce(
+                { event: 'uninteresting' } as PluginEvent,
+                ({ config, global } as unknown) as SalesforcePluginMeta,
+                'token',
+            )
+            expect(mockFetch).not.toHaveBeenCalled()
+        })
+
+        it('does send to a sink if there is a mapping for the event', async () => {
+            await sendEventToSalesforce(
+                ({
+                    event: '$pageview',
+                    properties: { unwanted: 'excluded', two: 'includes' },
+                } as unknown) as PluginEvent,
+                ({
+                    global: global,
+                    config: config,
+                    cache: undefined,
+                } as unknown) as SalesforcePluginMeta,
+                'the bearer token',
+            )
+            expect(mockFetch).toHaveBeenCalledWith('https://example.io/something', {
+                body: '{"two":"includes"}',
+                headers: { Authorization: 'Bearer the bearer token', 'Content-Type': 'application/json' },
+                method: 'POST',
             })
         })
     })

--- a/src/eventSinkMapping.test.ts
+++ b/src/eventSinkMapping.test.ts
@@ -14,164 +14,171 @@ const mockFetch = jest.fn()
 ;(global as any).fetch = mockFetch
 
 describe('event sink mapping', () => {
-    const invalidMapping: EventToSinkMapping = {
-        a: {
-            salesforcePath: 'something',
-            propertiesToInclude: '',
-            method: 'POST',
-        },
-        b: {
-            salesforcePath: '', // invalid because it does not have a salesforce path
-            propertiesToInclude: '',
-            method: 'POST',
-        },
-    }
-
-    const missingMethodInvalidMapping: EventToSinkMapping = {
-        a: {
-            salesforcePath: 'something',
-            propertiesToInclude: '',
-        } as EventSink,
-    }
-
-    const validMapping: EventToSinkMapping = {
-        $pageview: {
-            salesforcePath: 'something',
-            propertiesToInclude: 'one,two,three',
-            method: 'POST',
-        },
-    }
-
-    describe('parsing', () => {
-        it('can parse a valid event sink mapping', () => {
-            const config = ({ eventEndpointMapping: JSON.stringify(validMapping) } as unknown) as SalesforcePluginConfig
-            const mapping = parseEventSinkConfig(config)
-            expect(mapping).toEqual(validMapping)
-        })
-
-        it('can parse an empty event sink mapping', () => {
-            const config = ({ eventEndpointMapping: '' } as unknown) as SalesforcePluginConfig
-            const mapping = parseEventSinkConfig(config)
-            expect(mapping).toEqual(null)
-        })
-
-        it('can parse nonsense as an empty event sink mapping', () => {
-            const config = ({ eventEndpointMapping: '🤘' } as unknown) as SalesforcePluginConfig
-            expect(() => parseEventSinkConfig(config)).toThrowError(
-                'eventEndpointMapping must be an empty string or contain valid JSON!'
-            )
-        })
-    })
-
-    describe('validation', () => {
-        it('can validate an event sink mapping with missing salesforcePath', () => {
-            expect(() => {
-                verifyConfig(({
-                    config: {
-                        eventEndpointMapping: JSON.stringify(invalidMapping),
-                    },
-                } as unknown) as SalesforcePluginMeta)
-            }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
-        })
-
-        it('can validate an event sink mapping with missing method', () => {
-            expect(() => {
-                verifyConfig(({
-                    config: {
-                        eventEndpointMapping: JSON.stringify(missingMethodInvalidMapping),
-                    },
-                } as unknown) as SalesforcePluginMeta)
-            }).toThrowError('You must provide a method for each mapping in config.eventEndpointMapping.')
-        })
-
-        it('can validate invalid JSON in EventToSinkMapping', () => {
-            const mapping = ({
-                really: 'not an event to sink mapping',
-            } as unknown) as EventToSinkMapping
-            expect(() => {
-                verifyConfig(({
-                    config: {
-                        eventEndpointMapping: JSON.stringify(mapping),
-                    },
-                } as unknown) as SalesforcePluginMeta)
-            }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
-        })
-
-        it('can validate eventsToInclude must be present if an event sink mapping is not', () => {
-            expect(() => {
-                verifyConfig(({
-                    config: {
-                        eventEndpointMapping: '',
-                    },
-                } as unknown) as SalesforcePluginMeta)
-            }).toThrowError('If you are not providing an eventEndpointMapping then you must provide events to include.')
-        })
-
-        it('can validate that you should not send v1 and v2 config', () => {
-            const mapping: EventToSinkMapping = {
-                $pageView: {
-                    salesforcePath: 'something',
-                    propertiesToInclude: '',
-                    method: 'POST',
-                },
-            }
-            expect(() => {
-                verifyConfig(({
-                    config: {
-                        eventEndpointMapping: JSON.stringify(mapping),
-                        eventsToInclude: '$pageView',
-                    },
-                } as unknown) as SalesforcePluginMeta)
-            }).toThrowError('You should not provide both eventsToInclude and eventMapping.')
-        })
-    })
-
-    describe('sending to sink', () => {
-        const global = ({ logger: { debug: jest.fn(), error: jest.fn() } } as unknown) as SalesforcePluginMeta['global']
-        const config = {
-            salesforceHost: 'https://example.io',
-            eventMethodType: 'POST',
-            eventPath: '',
-            username: '',
-            password: '',
-            consumerKey: '',
-            consumerSecret: '',
-            eventsToInclude: '',
-            debugLogging: 'false',
-            eventEndpointMapping: JSON.stringify(validMapping),
+    describe('without field mappings', () => {
+        const invalidMapping: EventToSinkMapping = {
+            a: {
+                salesforcePath: 'something',
+                propertiesToInclude: '',
+                method: 'POST',
+            },
+            b: {
+                salesforcePath: '', // invalid because it does not have a salesforce path
+                propertiesToInclude: '',
+                method: 'POST',
+            },
         }
 
-        beforeEach(() => {
-            mockFetch.mockClear()
-            mockFetch.mockReturnValue(Promise.resolve({ status: 200 }))
-        })
+        const missingMethodInvalidMapping: EventToSinkMapping = {
+            a: {
+                salesforcePath: 'something',
+                propertiesToInclude: '',
+            } as EventSink,
+        }
 
-        it('does not send to a sink if there is no mapping for the event', async () => {
-            await sendEventToSalesforce(
-                { event: 'uninteresting' } as PluginEvent,
-                ({ config, global } as unknown) as SalesforcePluginMeta,
-                'token'
-            )
-            expect(mockFetch).not.toHaveBeenCalled()
-        })
-
-        it('does send to a sink if there is a mapping for the event', async () => {
-            await sendEventToSalesforce(
-                ({
-                    event: '$pageview',
-                    properties: { unwanted: 'excluded', two: 'includes' },
-                } as unknown) as PluginEvent,
-                ({
-                    global: global,
-                    config: config,
-                    cache: undefined,
-                } as unknown) as SalesforcePluginMeta,
-                'the bearer token'
-            )
-            expect(mockFetch).toHaveBeenCalledWith('https://example.io/something', {
-                body: '{"two":"includes"}',
-                headers: { Authorization: 'Bearer the bearer token', 'Content-Type': 'application/json' },
+        const validMapping: EventToSinkMapping = {
+            $pageview: {
+                salesforcePath: 'something',
+                propertiesToInclude: 'one,two,three',
                 method: 'POST',
+            },
+        }
+
+        describe('parsing', () => {
+            it('can parse a valid event sink mapping', () => {
+                const config = ({ eventEndpointMapping: JSON.stringify(validMapping) } as unknown) as SalesforcePluginConfig
+                const mapping = parseEventSinkConfig(config)
+                expect(mapping).toEqual(validMapping)
+            })
+
+            it('can parse an empty event sink mapping', () => {
+                const config = ({ eventEndpointMapping: '' } as unknown) as SalesforcePluginConfig
+                const mapping = parseEventSinkConfig(config)
+                expect(mapping).toEqual(null)
+            })
+
+            it('can parse nonsense as an empty event sink mapping', () => {
+                const config = ({ eventEndpointMapping: '🤘' } as unknown) as SalesforcePluginConfig
+                expect(() => parseEventSinkConfig(config)).toThrowError(
+                    'eventEndpointMapping must be an empty string or contain valid JSON!',
+                )
+            })
+        })
+
+        describe('validation', () => {
+            it('can validate an event sink mapping with missing salesforcePath', () => {
+                expect(() => {
+                    verifyConfig(({
+                        config: {
+                            eventEndpointMapping: JSON.stringify(invalidMapping),
+                        },
+                    } as unknown) as SalesforcePluginMeta)
+                }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
+            })
+
+            it('can validate an event sink mapping with missing method', () => {
+                expect(() => {
+                    verifyConfig(({
+                        config: {
+                            eventEndpointMapping: JSON.stringify(missingMethodInvalidMapping),
+                        },
+                    } as unknown) as SalesforcePluginMeta)
+                }).toThrowError('You must provide a method for each mapping in config.eventEndpointMapping.')
+            })
+
+            it('can validate invalid JSON in EventToSinkMapping', () => {
+                const mapping = ({
+                    really: 'not an event to sink mapping',
+                } as unknown) as EventToSinkMapping
+                expect(() => {
+                    verifyConfig(({
+                        config: {
+                            eventEndpointMapping: JSON.stringify(mapping),
+                        },
+                    } as unknown) as SalesforcePluginMeta)
+                }).toThrowError('You must provide a salesforce path for each mapping in config.eventEndpointMapping.')
+            })
+
+            it('can validate eventsToInclude must be present if an event sink mapping is not', () => {
+                expect(() => {
+                    verifyConfig(({
+                        config: {
+                            eventEndpointMapping: '',
+                        },
+                    } as unknown) as SalesforcePluginMeta)
+                }).toThrowError('If you are not providing an eventEndpointMapping then you must provide events to include.')
+            })
+
+            it('can validate that you should not send v1 and v2 config', () => {
+                const mapping: EventToSinkMapping = {
+                    $pageView: {
+                        salesforcePath: 'something',
+                        propertiesToInclude: '',
+                        method: 'POST',
+                    },
+                }
+                expect(() => {
+                    verifyConfig(({
+                        config: {
+                            eventEndpointMapping: JSON.stringify(mapping),
+                            eventsToInclude: '$pageView',
+                        },
+                    } as unknown) as SalesforcePluginMeta)
+                }).toThrowError('You should not provide both eventsToInclude and eventMapping.')
+            })
+        })
+
+        describe('sending to sink', () => {
+            const global = ({
+                logger: {
+                    debug: jest.fn(),
+                    error: jest.fn(),
+                },
+            } as unknown) as SalesforcePluginMeta['global']
+            const config = {
+                salesforceHost: 'https://example.io',
+                eventMethodType: 'POST',
+                eventPath: '',
+                username: '',
+                password: '',
+                consumerKey: '',
+                consumerSecret: '',
+                eventsToInclude: '',
+                debugLogging: 'false',
+                eventEndpointMapping: JSON.stringify(validMapping),
+            }
+
+            beforeEach(() => {
+                mockFetch.mockClear()
+                mockFetch.mockReturnValue(Promise.resolve({ status: 200 }))
+            })
+
+            it('does not send to a sink if there is no mapping for the event', async () => {
+                await sendEventToSalesforce(
+                    { event: 'uninteresting' } as PluginEvent,
+                    ({ config, global } as unknown) as SalesforcePluginMeta,
+                    'token',
+                )
+                expect(mockFetch).not.toHaveBeenCalled()
+            })
+
+            it('does send to a sink if there is a mapping for the event', async () => {
+                await sendEventToSalesforce(
+                    ({
+                        event: '$pageview',
+                        properties: { unwanted: 'excluded', two: 'includes' },
+                    } as unknown) as PluginEvent,
+                    ({
+                        global: global,
+                        config: config,
+                        cache: undefined,
+                    } as unknown) as SalesforcePluginMeta,
+                    'the bearer token',
+                )
+                expect(mockFetch).toHaveBeenCalledWith('https://example.io/something', {
+                    body: '{"two":"includes"}',
+                    headers: { Authorization: 'Bearer the bearer token', 'Content-Type': 'application/json' },
+                    method: 'POST',
+                })
             })
         })
     })

--- a/src/getProperties.test.ts
+++ b/src/getProperties.test.ts
@@ -31,15 +31,38 @@ describe('filtering by property allow list', () => {
         })
 
         it('can handle nested properties', () => {
-            const properties = { email: 'a', top: {middle: {bottom:'val'}} }
+            const properties = { name: 'a@b.com', person_properties: {middle: {bottom:'val'}, surname: 'Smith'} }
             const filteredProperties = getProperties(
                 ({ properties } as unknown) as PluginEvent,
-                'top',
-                {  } // TODO how do field mappings and nested properties interact
+                'person_properties.surname,name',
+                {
+                    name: 'Name',
+                    'person_properties.surname': 'LastName',
+                }
             )
 
-            // TODO - I don't actually understand what nested properties are, could do with an example here 🙈
-            expect(filteredProperties).toEqual('wat')
+            expect(filteredProperties).toEqual({
+                Name: 'a@b.com',
+                LastName: 'Smith'
+            })
+        })
+
+        it('maps fields when there are no properties to include provided', () => {
+            const properties = { name: 'a@b.com', another: 'value' }
+            const filteredProperties = getProperties(
+                ({ properties } as unknown) as PluginEvent,
+                '     ',
+                {
+                    name: 'Name',
+                    // redundant mapping is safely ignored
+                    'person_properties.surname': 'LastName',
+                }
+            )
+
+            expect(filteredProperties).toEqual({
+                Name: 'a@b.com',
+                another: 'value'
+            })
         })
     })
 })

--- a/src/getProperties.test.ts
+++ b/src/getProperties.test.ts
@@ -20,5 +20,26 @@ describe('filtering by property allow list', () => {
             const filteredProperties = getProperties(({ properties } as unknown) as PluginEvent, 'a,   c')
             expect(filteredProperties).toEqual({ a: 'a', c: 'c' })
         })
+
+        it('converts properties using field mappings', () => {
+            const properties = { email: 'a', b: 'b', surname: 'c', d: 'e' }
+            const filteredProperties = getProperties(
+                ({ properties } as unknown) as PluginEvent, 'email,surname,d',
+                { email: 'Email', surname: 'LastName' }
+            )
+            expect(filteredProperties).toEqual({ Email: 'a', LastName: 'c', d: 'e' })
+        })
+
+        it('can handle nested properties', () => {
+            const properties = { email: 'a', top: {middle: {bottom:'val'}} }
+            const filteredProperties = getProperties(
+                ({ properties } as unknown) as PluginEvent,
+                'top',
+                {  } // TODO how do field mappings and nested properties interact
+            )
+
+            // TODO - I don't actually understand what nested properties are, could do with an example here 🙈
+            expect(filteredProperties).toEqual('wat')
+        })
     })
 })

--- a/src/getProperties.test.ts
+++ b/src/getProperties.test.ts
@@ -47,6 +47,24 @@ describe('filtering by property allow list', () => {
             })
         })
 
+        it('can handle deeply nested properties', () => {
+            const properties = { name: 'a@b.com', person_properties: {middle: {bottom:'val'}, surname: 'Smith'} }
+            const filteredProperties = getProperties(
+                ({ properties } as unknown) as PluginEvent,
+                'person_properties.middle.bottom,name',
+                {
+                    name: 'Name',
+                    'person_properties.surname': 'LastName',
+                    'person_properties.middle.bottom': 'MiddleBottom'
+                }
+            )
+
+            expect(filteredProperties).toEqual({
+                Name: 'a@b.com',
+                MiddleBottom: 'val'
+            })
+        })
+
         it('maps fields when there are no properties to include provided', () => {
             const properties = { name: 'a@b.com', another: 'value' }
             const filteredProperties = getProperties(

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,7 +301,7 @@ async function statusOk(res: Response, logger: Logger): Promise<boolean> {
 }
 
 // just to get going!
-function getNestedProperty(obj: any, path: string): any {
+function getNestedProperty(obj: Record<string, any>, path: string): any {
     return path.split('.').reduce((acc, part) => acc && acc[part], obj);
 }
 
@@ -314,6 +314,8 @@ export function getProperties(event: PluginEvent, propertiesToInclude: string, f
         return {}
     }
 
+    // TODO not sending properties to include short-circuits to returning all properties
+    // TODO but skips applying mapping... when I guess we should apply mapping
     if (!propertiesToInclude?.trim()) {
         return properties
     }
@@ -331,7 +333,7 @@ export function getProperties(event: PluginEvent, propertiesToInclude: string, f
                 acc[trimmedKey] = value;
             }
         } else if (propertyKeys.includes(trimmedKey)) {
-            acc[trimmedKey] = properties[trimmedKey]
+            acc[mappedKey] = properties[trimmedKey]
         }
 
         return acc

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,7 +299,7 @@ async function statusOk(res: Response, logger: Logger): Promise<boolean> {
     return String(res.status)[0] === '2'
 }
 
-function getNestedProperty(obj: any, path: string): any {
+function getNestedProperty(obj: Record<string, unknown>, path: string): any {
     return path.split('.').reduce((acc, part) => acc && acc[part], obj);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,14 +300,13 @@ async function statusOk(res: Response, logger: Logger): Promise<boolean> {
     return String(res.status)[0] === '2'
 }
 
-// just to get going!
+// we allow `any` since we don't know what type the properties are, and `unknown` is too restrictive here
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getNestedProperty(properties: Record<string, any>, path: string): any {
-    return path.split('.').reduce((acc, part) => acc && acc[part], properties);
+    return path.split('.').reduce((acc, part) => acc[part], properties);
 }
 
 export function getProperties(event: PluginEvent, propertiesToInclude: string, fieldMappings: FieldMappings = {}): Properties {
-    // Spreading so the TypeScript compiler understands that in the
-    // reducer there's no way the properties will be undefined
     const { properties } = event
 
     if (!properties) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,9 @@ export interface EventSink {
     salesforcePath: string
     propertiesToInclude: string
     method: string
-    fieldMappings: FieldMappings
-
+    // NOTE: originally fieldMappings was not included, it should always be included now,
+    // but is optional for backwards compatibility
+    fieldMappings?: FieldMappings
 }
 
 export type FieldMappings = Record<string, string>;
@@ -190,7 +191,7 @@ export async function sendEventToSalesforce(
                 method: config.eventMethodType,
                 propertiesToInclude: config.propertiesToInclude,
                 fieldMappings: {}
-                
+
             }
             global.logger.debug('v1: processing event: ', event?.event, ' with sink ', eventSink)
         }
@@ -299,7 +300,8 @@ async function statusOk(res: Response, logger: Logger): Promise<boolean> {
     return String(res.status)[0] === '2'
 }
 
-function getNestedProperty(obj: Record<string, unknown>, path: string): any {
+// just to get going!
+function getNestedProperty(obj: any, path: string): any {
     return path.split('.').reduce((acc, part) => acc && acc[part], obj);
 }
 


### PR DESCRIPTION
[Mine couldn’t get PostHog-Salesforce integration to work](https://posthog.slack.com/archives/C02E3BKC78F/p1716351119831659) because of field mapping issues. 

Salesforce has some strict rules around naming and creating objects (e.g., each contact should have LastName, field name should be Email not email). 

Our current integration doesn’t allow for mapping PostHog properties to Salesforce fields 

so this PR adds mapping to enable something like the following:
"fieldMappings": { "LastName": "distinctId", "Email": "person_properties.email" }

field mappings are optional so this doesn't break existing config